### PR TITLE
in poll() loop: fixed lseek to begin of file otherwise revents do not…

### DIFF
--- a/s0vz.c
+++ b/s0vz.c
@@ -314,6 +314,10 @@ int main(void) {
 			
 					for (i=0; i<inputs; i++) {
 						if (fds[i].revents & POLLPRI) {
+						/* https://www.kernel.org/doc/Documentation/gpio/sysfs.txt */
+						/* [...] After poll(2) returns, either lseek(2) to 
+						the beginning of the sysfs file [...] */
+						lseek(fds[i].fd, 0, SEEK_SET);
 						len = read(fds[i].fd, buffer, BUF_LEN);
 						update_curl_handle(vzuuid[i]);
 						}


### PR DESCRIPTION
… get reset to 0 (resulting in endless interrupts and huge amount of kwh in vz)
